### PR TITLE
job: add duckdb to db

### DIFF
--- a/dagster/flowbyte_app/__init__.py
+++ b/dagster/flowbyte_app/__init__.py
@@ -43,6 +43,12 @@ duckdb_2_duckdb_job = define_asset_job(name="duckdb_2_duckdb", selection=["get_t
                                                                           "transform_data_duckdb_duckdb", 
                                                                           "add_destination_data_duckdb_duckdb"])
 
+duckdb_2_db_job = define_asset_job(name="duckdb_2_db", selection=["get_table_mapping_duckdb_db",
+                                                     "get_field_mapping_duckdb_db", 
+                                                     "get_source_data_duckdb_db", 
+                                                     "transform_data_duckdb_db", 
+                                                     "add_destination_data_duckdb_db"])
+
 
 
 
@@ -61,7 +67,8 @@ defs = Definitions(
             db_2_db_job,
             db_2_duckdb_job,
             adls_2_duckdb_job,
-            duckdb_2_duckdb_job
+            duckdb_2_duckdb_job,
+            duckdb_2_db_job
         ],
     schedules = [ db_to_db_schedule ],
     sensors = sensors ,


### PR DESCRIPTION
This pull request to `dagster/flowbyte_app` includes changes to add a new job and update the job list. The most important changes include defining a new asset job and including it in the list of jobs.

Job definition and updates:

* [`dagster/flowbyte_app/__init__.py`](diffhunk://#diff-b07ef3ea365259890948316520b3bb8532e6fa0d0a74ca6f320f2ebffb716667R46-R51): Defined a new asset job `duckdb_2_db_job` with specific tasks (`get_table_mapping_duckdb_db`, `get_field_mapping_duckdb_db`, `get_source_data_duckdb_db`, `transform_data_duckdb_db`, `add_destination_data_duckdb_db`).
* [`dagster/flowbyte_app/__init__.py`](diffhunk://#diff-b07ef3ea365259890948316520b3bb8532e6fa0d0a74ca6f320f2ebffb716667L64-R71): Added the newly defined `duckdb_2_db_job` to the list of jobs.